### PR TITLE
feat(paper): 共有認証クライアントへ移行し、開き直してもログイン状態を保つ

### DIFF
--- a/infra/functions/site-auth.test.mjs
+++ b/infra/functions/site-auth.test.mjs
@@ -34,6 +34,8 @@ const PUBLIC = [
   // Cognito ログインを開始する静的な殻。記事・要約は含まない
   '/paper/',
   '/paper/index.html',
+  // 共有認証クライアント。許可し忘れると index.html の import が404になり起動しない
+  '/paper/vendor/imai-auth-browser.js',
   '/paper/manifest.webmanifest',
   '/paper/icon.svg',
   '/paper/icon-512.png',
@@ -52,6 +54,8 @@ const PRIVATE = [
   '/archive/2026-08-10-morning.json',
   '/notes/2026-08-09.md',
   // 素朴なパターンマッチを抜けにいく形
+  '/paper/vendor/../data.json',
+  '/paper/vendor/other.js',
   '/assets/../paper/data.json',
   '/assets/sub/dir/secret.json',
   '/Index.html',

--- a/infra/functions/site-path-guard.js
+++ b/infra/functions/site-path-guard.js
@@ -13,6 +13,8 @@ var PUBLIC_PATHS = [
   /^\/robots\.txt$/,
   // 認証開始と OAuth コールバックを処理する。機密データは HTML 内に置かない
   /^\/paper\/index\.html$/,
+  // imai-auth の共有認証クライアント（生成物）。index.html が import する。
+  /^\/paper\/vendor\/imai-auth-browser\.js$/,
   /^\/paper\/manifest\.webmanifest$/,
   /^\/paper\/icon\.svg$/,
   /^\/paper\/favicon-32\.png$/,

--- a/src/site/static/paper/field-trends.test.mjs
+++ b/src/site/static/paper/field-trends.test.mjs
@@ -13,7 +13,11 @@ import { test } from 'node:test';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const html = fs.readFileSync(path.join(here, 'index.html'), 'utf-8');
-const scriptBody = html.split('<script>\n')[1].split('\n(function () {')[0];
+// index.html の script は type="module"。import 行は new Function で評価できないので落とす。
+const scriptBody = html
+  .split('<script type="module">\n')[1]
+  .split('\n(function () {')[0]
+  .replace(/^import .*$/gm, '');
 
 const { buildFieldTrends, weekStart } = new Function(
   `${scriptBody}; return { buildFieldTrends: buildFieldTrends, weekStart: weekStart };`

--- a/src/site/static/paper/highlights.test.mjs
+++ b/src/site/static/paper/highlights.test.mjs
@@ -13,7 +13,11 @@ import { test } from 'node:test';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const html = fs.readFileSync(path.join(here, 'index.html'), 'utf-8');
-const scriptBody = html.split('<script>\n')[1].split('\n(function () {')[0];
+// index.html の script は type="module"。import 行は new Function で評価できないので落とす。
+const scriptBody = html
+  .split('<script type="module">\n')[1]
+  .split('\n(function () {')[0]
+  .replace(/^import .*$/gm, '');
 
 const { selectMorningHighlights } = new Function(
   `${scriptBody}; return { selectMorningHighlights: selectMorningHighlights };`

--- a/src/site/static/paper/index.html
+++ b/src/site/static/paper/index.html
@@ -601,7 +601,8 @@
   </section>
 </div>
 
-<script>
+<script type="module">
+import { createAuthClient, isSignedOut, isTransient } from './vendor/imai-auth-browser.js';
 /** 2つの ISO 日付（YYYY-MM-DD）の日数差。JST 固定で正午基準にし、DST 等の揺れを避ける */
 function dayDiff(a, b) {
   return Math.round((Date.parse(b + 'T00:00:00+09:00') - Date.parse(a + 'T00:00:00+09:00')) / 864e5);
@@ -906,7 +907,6 @@ function buildSearchResult(articles, stories, query, filters) {
     });
   };
   var D = null, ART = null, TOPIC = null;
-  var AUTH_CONFIG = null;
   var READ_KEY = 'morning-agent.paper.read';
   var VIEW_KEY = 'morning-agent.paper.view';
   var unreadOnly = false;
@@ -930,190 +930,47 @@ function buildSearchResult(articles, stories, query, filters) {
     });
   }
 
-  // Cognito Hosted UI（Authorization Code + PKCE）。パスワードも署名検証もこの画面では扱わない。
-  var TOKEN_KEY = 'morning-agent.paper.tokens';
-  var VERIFIER_KEY = 'morning-agent.paper.pkce.verifier';
-  var STATE_KEY = 'morning-agent.paper.pkce.state';
-
-  function base64Url(bytes) {
-    var str = '';
-    var arr = new Uint8Array(bytes);
-    for (var i = 0; i < arr.length; i++) str += String.fromCharCode(arr[i]);
-    return btoa(str).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
-  }
-
-  function randomString(length) {
-    var bytes = new Uint8Array(length);
-    crypto.getRandomValues(bytes);
-    return base64Url(bytes.buffer);
-  }
-
-  function challenge(verifier) {
-    return crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier)).then(base64Url);
-  }
-
-  function loadTokens() {
-    var raw = sessionStorage.getItem(TOKEN_KEY);
-    if (!raw) return null;
-    try { return JSON.parse(raw); } catch (_) { return null; }
-  }
-
-  function clearTokens() {
-    sessionStorage.removeItem(TOKEN_KEY);
-  }
-
-  function saveTokenResponse(json) {
-    if (!json.access_token || !json.expires_in) throw new Error('token response is incomplete');
-    var old = loadTokens();
-    sessionStorage.setItem(TOKEN_KEY, JSON.stringify({
-      access_token: json.access_token,
-      refresh_token: json.refresh_token || (old && old.refresh_token),
-      // 期限直前のリクエストを避けるため30秒早めに更新する
-      expires_at: Date.now() + (json.expires_in - 30) * 1000
-    }));
-  }
-
-  function tokenRequest(config, body) {
-    return fetch(config.cognitoDomain + '/oauth2/token', {
-      method: 'POST',
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams(body)
-    }).then(function (r) {
-      if (!r.ok) throw new Error('token endpoint returned ' + r.status);
-      return r.json();
-    });
-  }
-
-  function startLogin(config) {
-    var verifier = randomString(64);
-    var state = randomString(16);
-    sessionStorage.setItem(VERIFIER_KEY, verifier);
-    sessionStorage.setItem(STATE_KEY, state);
-    return challenge(verifier).then(function (codeChallenge) {
-      var params = new URLSearchParams({
-        response_type: 'code',
-        client_id: config.clientId,
-        redirect_uri: config.redirectUri,
-        scope: config.scopes,
-        state: state,
-        code_challenge: codeChallenge,
-        code_challenge_method: 'S256'
-      });
-      window.location.assign(config.cognitoDomain + '/oauth2/authorize?' + params.toString());
-      return null;
-    });
-  }
-
-  // OAuth の返却値を取り出し、同時に URL から消す。
+  // 認証は imai-auth の共有クライアントへ委譲する（vendor/imai-auth-browser.js）。
+  // PKCE・token保管・更新・logoutをこの画面で書かない。
   //
-  // 消すのは**交換を試みる前**。交換の完了を待たずにタブを閉じると、ブラウザの
-  // 「閉じたタブを開く」機能がこの URL と sessionStorage をまとめて復元し、
-  // 使用済み code で交換を再試行して失敗する。成功後にしか消していないと、
-  // 手動リロードでも同じ dead code を使い続けてエラーがループする。
-  function takeOAuthCallback() {
-    var names = ['code', 'state', 'error', 'error_description', 'error_uri'];
-    var url = new URL(window.location.href);
-    var result = {
-      code: url.searchParams.get('code'),
-      state: url.searchParams.get('state'),
-      error: url.searchParams.get('error')
-    };
-    var present = names.some(function (name) { return url.searchParams.has(name); });
-    if (present) {
-      names.forEach(function (name) { url.searchParams.delete(name); });
-      var query = url.searchParams.toString();
-      try {
-        window.history.replaceState(null, '', url.pathname + (query ? '?' + query : '') + url.hash);
-      } catch (_) { /* 非致命 */ }
-    }
-    return result;
-  }
+  // 以前はRefresh TokenをここでsessionStorageに置いていたため、PWAを終了すると
+  // 更新すべきtoken自体が消え、開くたびにHosted UIへ飛んでいた。共有クライアント
+  // はIndexedDBへ永続化するので、再起動してもログイン状態が続く。
+  var auth = null;
 
-  function exchangeCode(config, code, verifier) {
-    return tokenRequest(config, {
-      grant_type: 'authorization_code',
-      client_id: config.clientId,
-      code: code,
-      redirect_uri: config.redirectUri,
-      code_verifier: verifier
-    }).then(function (json) {
-      saveTokenResponse(json);
-      return loadTokens().access_token;
+  function initAuth(config) {
+    auth = createAuthClient({
+      clientId: config.clientId,
+      redirectUri: config.redirectUri,
+      scopes: config.scopes,
+      authDomain: config.cognitoDomain,
+      storageNamespace: 'morning-agent-paper'
     });
+    return auth;
   }
 
-  function existingOrRefresh(config) {
-    var tokens = loadTokens();
-    if (tokens && tokens.access_token && tokens.expires_at > Date.now()) {
-      return Promise.resolve(tokens.access_token);
-    }
-    if (tokens && tokens.refresh_token) return refresh(config, tokens.refresh_token);
-    return Promise.resolve(null);
-  }
-
-  function refresh(config, refreshToken) {
-    return tokenRequest(config, {
-      grant_type: 'refresh_token',
-      client_id: config.clientId,
-      refresh_token: refreshToken
-    }).then(function (json) {
-      saveTokenResponse(json);
-      return loadTokens().access_token;
-    }).catch(function () {
-      clearTokens();
-      return null;
-    });
-  }
-
-  function ensureAuthenticated(config) {
-    var callback = takeOAuthCallback();
-    var expected = sessionStorage.getItem(STATE_KEY);
-    var verifier = sessionStorage.getItem(VERIFIER_KEY);
-    var fallback = function () {
-      return existingOrRefresh(config).then(function (token) {
-        return token || startLogin(config);
-      });
-    };
-
-    if (callback.code && expected && verifier && expected === callback.state) {
-      sessionStorage.removeItem(VERIFIER_KEY);
-      sessionStorage.removeItem(STATE_KEY);
-      // code が使用済み・期限切れでも画面を壊さない。既存トークンの確認・
-      // 再ログインへ落とす。
-      return exchangeCode(config, callback.code, verifier).catch(fallback);
-    }
-
-    if (callback.code || callback.error) {
-      // state 不一致、PKCE の控えが無い重複コールバック(ログイン済みタブで
-      // ブラウザバックすると、有効な Managed Login cookie のせいで新しい
-      // code が自動発行されて戻ってくる)、ログインの取り消し。どれも致命的
-      // ではないので、使い切った控えを掃除して既存トークンの確認へ落とす。
-      sessionStorage.removeItem(VERIFIER_KEY);
-      sessionStorage.removeItem(STATE_KEY);
-    }
-    return fallback();
+  /** #err にメッセージと1つのボタンを出す。ログアウト後とオフラインで使う。 */
+  function showNotice(message, label, onClick) {
+    $('date').textContent = '';
+    $('err').hidden = false;
+    $('err').textContent = message;
+    if (!label) return;
+    var button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'retry';
+    button.textContent = label;
+    button.addEventListener('click', onClick);
+    $('err').appendChild(button);
   }
 
   $('logout').addEventListener('click', function () {
-    var tokens = loadTokens();
-    clearTokens();
-    sessionStorage.removeItem(VERIFIER_KEY);
-    sessionStorage.removeItem(STATE_KEY);
-    if (!AUTH_CONFIG) return window.location.assign('/');
-    var params = new URLSearchParams({
-      client_id: AUTH_CONFIG.clientId,
-      logout_uri: AUTH_CONFIG.logoutUri
+    if (!auth) return window.location.assign('/paper/');
+    // product-local logout。共有Managed Loginのcookieは切らないので、他プロダクト
+    // のSSOは保たれる。ここで再認証へ行くとcookieが生きている限り無言で再ログイン
+    // してしまうため、専用の表示に留めて明示的な「ログイン」を待つ。
+    auth.logout().then(function () {
+      window.location.assign('/paper/');
     });
-    var goToLogout = function () {
-      window.location.assign(AUTH_CONFIG.cognitoDomain + '/logout?' + params.toString());
-    };
-    if (!tokens || !tokens.refresh_token) return goToLogout();
-    // revokeが失敗しても(オフライン等)ローカルログアウトは継続する。
-    fetch(AUTH_CONFIG.cognitoDomain + '/oauth2/revoke', {
-      method: 'POST',
-      headers: { 'content-type': 'application/x-www-form-urlencoded' },
-      body: new URLSearchParams({ token: tokens.refresh_token, client_id: AUTH_CONFIG.clientId })
-    }).catch(function () {}).then(goToLogout, goToLogout);
   });
 
   // #39: Passkey登録・ログアウトは1つの起点(account-menu-btn)から開くメニューに集約する
@@ -1153,46 +1010,57 @@ function buildSearchResult(articles, stories, query, filters) {
   fetch('/paper/auth-config.json', { cache: 'no-store' })
     .then(function (r) { if (!r.ok) throw new Error('認証設定 HTTP ' + r.status); return r.json(); })
     .then(function (config) {
-      AUTH_CONFIG = config;
-      return ensureAuthenticated(config).then(function (token) {
-        if (!token) return null; // Hosted UI へ遷移中
+      initAuth(config);
+      // セッションが無ければ共有クライアントがHosted UIへ遷移する
+      // (このPromiseは解決しない)。callbackの処理も同じ経路で行われる。
+      return auth.ensureAuthenticated().then(function () {
         $('logout').hidden = false;
         var passkeyAdd = $('passkey-add');
-        passkeyAdd.href = config.cognitoDomain + '/passkeys/add?' + new URLSearchParams({
-          client_id: config.clientId,
-          redirect_uri: config.redirectUri
-        }).toString();
+        passkeyAdd.href = auth.getPasskeyAddUrl();
         passkeyAdd.hidden = false;
         $('account-menu-btn').hidden = false;
-        var headers = {};
-        headers[config.tokenHeader || 'x-morning-token'] = token;
-        return fetch('/paper/data.json', { cache: 'no-store', headers: headers }).then(function (r) {
-          if (r.status === 401) {
-            clearTokens();
-            return startLogin(config);
-          }
-          if (!r.ok) throw new Error('紙面データ HTTP ' + r.status);
-          return r.json();
+        return auth.getAccessToken().then(function (token) {
+          var headers = {};
+          // CloudFront OAC が Authorization を占有するため、product固有ヘッダを使う。
+          headers[config.tokenHeader || 'x-morning-token'] = token;
+          return fetch('/paper/data.json', { cache: 'no-store', headers: headers }).then(function (r) {
+            if (r.status === 401) {
+              // まだ有効かもしれないRefresh Tokenは捨てない。ログインし直せば
+              // 共有クライアントが更新か再認証を選ぶ。
+              return auth.login();
+            }
+            if (!r.ok) throw new Error('紙面データ HTTP ' + r.status);
+            return r.json();
+          });
         });
       });
     })
     .then(function (data) { if (data) init(data); })
     .catch(function (e) {
-      $('date').textContent = '';
-      $('err').hidden = false;
-      $('err').textContent = '認証または紙面データの読み込みに失敗しました（' + e.message + '）。';
-      // 認可コードは一度しか使えないため、失敗時はURLから落として再ログインできるようにする。
-      try { window.history.replaceState(null, '', window.location.pathname); } catch (_) { /* 非致命 */ }
-      var retry = document.createElement('button');
-      retry.type = 'button';
-      retry.className = 'retry';
-      retry.textContent = 'ログインをやり直す';
-      retry.addEventListener('click', function () {
-        clearTokens();
-        if (AUTH_CONFIG) startLogin(AUTH_CONFIG);
-        else window.location.reload();
-      });
-      $('err').appendChild(retry);
+      // ログアウト済み。共有cookieが生きている限り、ここで再認証へ行くと無言で
+      // 再ログインし、押したログアウトが無かったことになる。
+      if (isSignedOut(e)) {
+        return showNotice('ログアウトしました。', 'ログイン', function () {
+          if (auth) auth.login();
+        });
+      }
+      // オフライン。Hosted UIへ飛ばしても壊れたページに着くだけで、
+      // Refresh Tokenは手元に残っている。
+      if (isTransient(e)) {
+        return showNotice(
+          'オフラインのようです。通信状況を確認して、開き直してください。ログイン状態は保たれています。',
+          '再読み込み',
+          function () { window.location.assign('/paper/'); }
+        );
+      }
+      showNotice(
+        '認証または紙面データの読み込みに失敗しました（' + e.message + '）。',
+        'ログインをやり直す',
+        function () {
+          if (auth) auth.login();
+          else window.location.assign('/paper/');
+        }
+      );
     });
 
   function init(d) {

--- a/src/site/static/paper/search-result.test.mjs
+++ b/src/site/static/paper/search-result.test.mjs
@@ -14,7 +14,11 @@ import { test } from 'node:test';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const html = fs.readFileSync(path.join(here, 'index.html'), 'utf-8');
-const scriptBody = html.split('<script>\n')[1].split('\n(function () {')[0];
+// index.html の script は type="module"。import 行は new Function で評価できないので落とす。
+const scriptBody = html
+  .split('<script type="module">\n')[1]
+  .split('\n(function () {')[0]
+  .replace(/^import .*$/gm, '');
 
 const { buildSearchResult, highlightMatch } = new Function(
   `${scriptBody}; return { buildSearchResult: buildSearchResult, highlightMatch: highlightMatch };`

--- a/src/site/static/paper/story-narrative.test.mjs
+++ b/src/site/static/paper/story-narrative.test.mjs
@@ -13,7 +13,11 @@ import { test } from 'node:test';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const html = fs.readFileSync(path.join(here, 'index.html'), 'utf-8');
-const scriptBody = html.split('<script>\n')[1].split('\n(function () {')[0];
+// index.html の script は type="module"。import 行は new Function で評価できないので落とす。
+const scriptBody = html
+  .split('<script type="module">\n')[1]
+  .split('\n(function () {')[0]
+  .replace(/^import .*$/gm, '');
 
 const { buildStoryNarrative } = new Function(
   `${scriptBody}; return { buildStoryNarrative: buildStoryNarrative };`

--- a/src/site/static/paper/today-groups.test.mjs
+++ b/src/site/static/paper/today-groups.test.mjs
@@ -13,7 +13,11 @@ import { test } from 'node:test';
 
 const here = path.dirname(fileURLToPath(import.meta.url));
 const html = fs.readFileSync(path.join(here, 'index.html'), 'utf-8');
-const scriptBody = html.split('<script>\n')[1].split('\n(function () {')[0];
+// index.html の script は type="module"。import 行は new Function で評価できないので落とす。
+const scriptBody = html
+  .split('<script type="module">\n')[1]
+  .split('\n(function () {')[0]
+  .replace(/^import .*$/gm, '');
 
 const { classifyTodayArticles } = new Function(
   `${scriptBody}; return { classifyTodayArticles: classifyTodayArticles };`

--- a/src/site/static/paper/vendor/imai-auth-browser.js
+++ b/src/site/static/paper/vendor/imai-auth-browser.js
@@ -1,0 +1,414 @@
+// ============================================================
+// GENERATED FILE — DO NOT EDIT
+//
+// imai-auth shared browser auth client
+// version: 1.1.0
+// source:  https://github.com/pyonta0215/imai-auth  packages/browser/
+//
+// 直したいときは imai-auth 側を直し、release から vendor 更新 PR を
+// 受け取ること。ここを手で書き換えると次の同期で失われる。
+// ============================================================
+
+// packages/browser/src/imai-auth-browser.ts
+var AuthFatalError = class extends Error {
+  kind = "fatal";
+  constructor(message, options) {
+    super(message, options);
+    this.name = "AuthFatalError";
+  }
+};
+var AuthTransientError = class extends Error {
+  kind = "transient";
+  constructor(message, options) {
+    super(message, options);
+    this.name = "AuthTransientError";
+  }
+};
+function isTransient(error) {
+  return error instanceof AuthTransientError;
+}
+var AuthSignedOutError = class extends Error {
+  kind = "signed-out";
+  constructor() {
+    super("signed out from this product");
+    this.name = "AuthSignedOutError";
+  }
+};
+function isSignedOut(error) {
+  return error instanceof AuthSignedOutError;
+}
+function base64Url(input) {
+  const bytes = input instanceof Uint8Array ? input : new Uint8Array(input);
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+function randomString(byteLength, cryptoApi) {
+  const bytes = new Uint8Array(byteLength);
+  cryptoApi.getRandomValues(bytes);
+  return base64Url(bytes);
+}
+async function pkceChallenge(verifier, cryptoApi) {
+  const digest = await cryptoApi.subtle.digest("SHA-256", new TextEncoder().encode(verifier));
+  return base64Url(digest);
+}
+function createMemoryStore(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    async read(key) {
+      return values.get(key) ?? null;
+    },
+    async write(key, value) {
+      values.set(key, value);
+    },
+    async remove(key) {
+      values.delete(key);
+    }
+  };
+}
+var STORE_NAME = "tokens";
+function promisify(request) {
+  return new Promise((resolve, reject) => {
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+  });
+}
+function openDatabase(factory, name) {
+  return new Promise((resolve, reject) => {
+    const request = factory.open(name, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(STORE_NAME)) {
+        request.result.createObjectStore(STORE_NAME);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error("indexedDB open blocked"));
+  });
+}
+function createIndexedDbStore(namespace, factory) {
+  const dbName = `imai-auth:${namespace}`;
+  let fallback = null;
+  let opening = null;
+  async function connect() {
+    if (!opening) {
+      opening = openDatabase(factory, dbName).catch((cause) => {
+        opening = null;
+        throw cause;
+      });
+    }
+    return opening;
+  }
+  async function withStore(mode, run) {
+    const connection = await connect();
+    const transaction = connection.transaction(STORE_NAME, mode);
+    return promisify(run(transaction.objectStore(STORE_NAME)));
+  }
+  function degrade() {
+    if (!fallback) fallback = createMemoryStore();
+    return fallback;
+  }
+  return {
+    async read(key) {
+      if (fallback) return fallback.read(key);
+      try {
+        const value = await withStore("readonly", (store) => store.get(key));
+        return typeof value === "string" ? value : null;
+      } catch {
+        return degrade().read(key);
+      }
+    },
+    async write(key, value) {
+      if (fallback) return fallback.write(key, value);
+      try {
+        await withStore("readwrite", (store) => store.put(value, key));
+      } catch {
+        await degrade().write(key, value);
+      }
+    },
+    async remove(key) {
+      if (fallback) return fallback.remove(key);
+      try {
+        await withStore("readwrite", (store) => store.delete(key));
+      } catch {
+        await degrade().remove(key);
+      }
+    }
+  };
+}
+var DEFAULT_AUTH_DOMAIN = "https://auth.imai.me";
+var DEFAULT_SCOPES = "openid email aws.cognito.signin.user.admin";
+var EXPIRY_MARGIN_MS = 6e4;
+var RT_KEY = "refresh_token";
+var SIGNED_OUT_KEY = "signed_out";
+var PKCE_KEY = "imai-auth:pkce";
+var OAUTH_PARAMS = ["code", "state", "error", "error_description", "error_uri"];
+var FATAL_OAUTH_ERRORS = /* @__PURE__ */ new Set(["invalid_grant", "invalid_client", "unauthorized_client"]);
+function defaultLockRunner() {
+  const locks = globalThis.navigator?.locks;
+  if (!locks) {
+    return (_name, run) => run();
+  }
+  return (name, run) => locks.request(name, run);
+}
+function defaultOnResume(handler) {
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "visible") handler();
+    });
+  }
+  if (typeof window !== "undefined") {
+    window.addEventListener("online", handler);
+  }
+}
+function defaultStore(namespace) {
+  const factory = globalThis.indexedDB;
+  return factory ? createIndexedDbStore(namespace, factory) : createMemoryStore();
+}
+function takeOAuthCallback(href, history) {
+  const url = new URL(href);
+  const result = {
+    code: url.searchParams.get("code"),
+    state: url.searchParams.get("state"),
+    error: url.searchParams.get("error"),
+    present: OAUTH_PARAMS.some((name) => url.searchParams.has(name))
+  };
+  if (result.present) {
+    for (const name of OAUTH_PARAMS) url.searchParams.delete(name);
+    const query = url.searchParams.toString();
+    try {
+      history.replaceState(null, "", `${url.pathname}${query ? `?${query}` : ""}${url.hash}`);
+    } catch {
+    }
+  }
+  return result;
+}
+function createAuthClient(config, overrides = {}) {
+  const authDomain = (config.authDomain ?? DEFAULT_AUTH_DOMAIN).replace(/\/$/, "");
+  const scopes = config.scopes ?? DEFAULT_SCOPES;
+  const store = overrides.store ?? defaultStore(config.storageNamespace);
+  const pending = overrides.sessionStorage ?? globalThis.sessionStorage;
+  const cryptoApi = overrides.crypto ?? globalThis.crypto;
+  const fetchApi = overrides.fetch ?? globalThis.fetch.bind(globalThis);
+  const location = overrides.location ?? globalThis.location;
+  const history = overrides.history ?? globalThis.history;
+  const now = overrides.now ?? Date.now;
+  const withLock = overrides.withLock ?? defaultLockRunner();
+  const onResume = overrides.onResume ?? defaultOnResume;
+  const lockName = `imai-auth:refresh:${config.storageNamespace}`;
+  let session = null;
+  let inFlight = null;
+  let resumeAttached = false;
+  function isUsable(candidate) {
+    return candidate !== null && candidate.expiresAt - EXPIRY_MARGIN_MS > now();
+  }
+  async function readErrorCode(response) {
+    try {
+      const body = await response.json();
+      return typeof body.error === "string" ? body.error : "";
+    } catch {
+      return "";
+    }
+  }
+  async function tokenRequest(body) {
+    let response;
+    try {
+      response = await fetchApi(`${authDomain}/oauth2/token`, {
+        method: "POST",
+        cache: "no-store",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams(body).toString()
+      });
+    } catch (cause) {
+      throw new AuthTransientError("token endpoint unreachable", { cause });
+    }
+    if (response.ok) return await response.json();
+    if (response.status === 400 || response.status === 401) {
+      const code = await readErrorCode(response);
+      if (FATAL_OAUTH_ERRORS.has(code)) {
+        throw new AuthFatalError(`token endpoint rejected the grant: ${code}`);
+      }
+    }
+    throw new AuthTransientError(`token endpoint returned ${response.status}`);
+  }
+  async function acceptTokens(json) {
+    if (typeof json.access_token !== "string" || !Number.isFinite(json.expires_in)) {
+      throw new AuthTransientError("token response is incomplete");
+    }
+    if (json.refresh_token) await store.write(RT_KEY, json.refresh_token);
+    session = {
+      accessToken: json.access_token,
+      idToken: json.id_token ?? null,
+      expiresAt: now() + json.expires_in * 1e3
+    };
+    return session;
+  }
+  function refreshTokens() {
+    if (inFlight) return inFlight;
+    const run = withLock(lockName, async () => {
+      if (isUsable(session)) return session;
+      const stored = await store.read(RT_KEY);
+      if (!stored) throw new AuthFatalError("no refresh token");
+      try {
+        return await acceptTokens(
+          await tokenRequest({
+            grant_type: "refresh_token",
+            client_id: config.clientId,
+            refresh_token: stored
+          })
+        );
+      } catch (cause) {
+        if (!isTransient(cause)) await store.remove(RT_KEY);
+        throw cause;
+      }
+    }).finally(() => {
+      if (inFlight === run) inFlight = null;
+    });
+    inFlight = run;
+    return run;
+  }
+  function attachResume() {
+    if (resumeAttached) return;
+    resumeAttached = true;
+    onResume(() => {
+      if (isUsable(session)) return;
+      void refreshTokens().catch(() => void 0);
+    });
+  }
+  async function startLogin() {
+    const verifier = randomString(64, cryptoApi);
+    const state = randomString(24, cryptoApi);
+    pending.setItem(PKCE_KEY, JSON.stringify({ verifier, state }));
+    const params = new URLSearchParams({
+      client_id: config.clientId,
+      response_type: "code",
+      scope: scopes,
+      redirect_uri: config.redirectUri,
+      state,
+      code_challenge: await pkceChallenge(verifier, cryptoApi),
+      code_challenge_method: "S256"
+    });
+    location.replace(`${authDomain}/oauth2/authorize?${params.toString()}`);
+    return new Promise(() => {
+    });
+  }
+  async function handleCallback() {
+    const callback = takeOAuthCallback(location.href, history);
+    if (!callback.present) return;
+    const storedRaw = pending.getItem(PKCE_KEY);
+    pending.removeItem(PKCE_KEY);
+    if (callback.error || !callback.code || !storedRaw) return;
+    let stored;
+    try {
+      stored = JSON.parse(storedRaw);
+    } catch {
+      return;
+    }
+    if (typeof stored.verifier !== "string" || stored.state !== callback.state) return;
+    try {
+      await acceptTokens(
+        await tokenRequest({
+          grant_type: "authorization_code",
+          client_id: config.clientId,
+          code: callback.code,
+          redirect_uri: config.redirectUri,
+          code_verifier: stored.verifier
+        })
+      );
+      await store.remove(SIGNED_OUT_KEY);
+    } catch {
+    }
+  }
+  async function revokeRefreshToken() {
+    const stored = await store.read(RT_KEY);
+    await store.remove(RT_KEY);
+    session = null;
+    pending.removeItem(PKCE_KEY);
+    if (!stored) return;
+    try {
+      await fetchApi(`${authDomain}/oauth2/revoke`, {
+        method: "POST",
+        cache: "no-store",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({ token: stored, client_id: config.clientId }).toString()
+      });
+    } catch {
+    }
+  }
+  async function isSignedOutFlagSet() {
+    return await store.read(SIGNED_OUT_KEY) === "true";
+  }
+  async function restore() {
+    await handleCallback();
+    if (isUsable(session)) {
+      attachResume();
+      return true;
+    }
+    if (await isSignedOutFlagSet()) return false;
+    try {
+      await refreshTokens();
+      attachResume();
+      return true;
+    } catch (cause) {
+      if (isTransient(cause)) throw cause;
+      return false;
+    }
+  }
+  return {
+    restore,
+    async ensureAuthenticated() {
+      if (await restore()) return;
+      if (await isSignedOutFlagSet()) {
+        throw new AuthSignedOutError();
+      }
+      await startLogin();
+    },
+    async getAccessToken() {
+      if (isUsable(session)) return session.accessToken;
+      return (await refreshTokens()).accessToken;
+    },
+    getIdToken() {
+      return session?.idToken ?? null;
+    },
+    async login() {
+      await store.remove(SIGNED_OUT_KEY);
+      return startLogin();
+    },
+    async logout() {
+      await revokeRefreshToken();
+      await store.write(SIGNED_OUT_KEY, "true");
+    },
+    async signOutEverywhere() {
+      await revokeRefreshToken();
+      await store.write(SIGNED_OUT_KEY, "true");
+      const params = new URLSearchParams({
+        client_id: config.clientId,
+        logout_uri: config.redirectUri
+      });
+      location.assign(`${authDomain}/logout?${params.toString()}`);
+      return new Promise(() => {
+      });
+    },
+    getPasskeyAddUrl() {
+      const params = new URLSearchParams({
+        client_id: config.clientId,
+        redirect_uri: config.redirectUri
+      });
+      return `${authDomain}/passkeys/add?${params.toString()}`;
+    }
+  };
+}
+export {
+  AuthFatalError,
+  AuthSignedOutError,
+  AuthTransientError,
+  base64Url,
+  createAuthClient,
+  createIndexedDbStore,
+  createMemoryStore,
+  isSignedOut,
+  isTransient,
+  pkceChallenge,
+  randomString,
+  takeOAuthCallback
+};


### PR DESCRIPTION
共有ブラウザ認証クライアントへ移行します。7 プロダクト横断の統一で、これが最後の 1 本です。

## なぜ

Refresh Token をこの画面の `sessionStorage` に置いていたため、PWA を終了すると更新すべきトークン自体が消えていました。開くたびに Hosted UI へ飛び、Managed Login cookie（AWS 仕様で 1 時間固定）が切れていれば再ログインを求められます。

## 変わること

| | 前 | 後 |
|---|---|---|
| Refresh Token | `sessionStorage` | IndexedDB（永続） |
| Access Token | `sessionStorage` | メモリのみ |
| 更新の排他 | なし | single-flight + Web Locks |
| 通信失敗時 | トークンを破棄 | 保持して再試行 |
| ログアウト | 共有 cookie も切る | product-local |

PKCE・トークン保管・更新・ログアウトの実装（約 170 行）が消え、設定を渡して呼ぶだけになりました。

`data.json` が 401 のときに `clearTokens()` を呼ぶのもやめています。まだ有効かもしれない Refresh Token を捨てる必要はなく、ログインし直せば共有クライアントが更新か再認証を選びます。

## script を type="module" にしています

vendored クライアントは ESM なので、`<script>` を `<script type="module">` に変えました。

- inline の `onclick` 等は 0 件（確認済み）
- 既存の IIFE 構造はそのまま
- 元から `body` 末尾にあり DOM 構築後に走っていたので、実行タイミングは変わりません

## インフラの変更を 1 行

CloudFront の path guard は fail-closed なので、`/paper/vendor/imai-auth-browser.js` を許可リストへ追加しています。**忘れると `index.html` の import が 404 になって起動しません。** 許可の回帰テストに加え、`vendor` 配下を抜けにいくパス（`/paper/vendor/../data.json`、`/paper/vendor/other.js`）が閉じたままであることも検証しています。

## UI の追加

- **ログアウト後** — 専用の表示に留めて明示的な「ログイン」を待ちます。ここで再認証へ行くと、共有 cookie が生きている限り無言で再ログインし、押したログアウトが無かったことになります。
- **オフラインで復元できない** — Hosted UI へ飛ばしません（壊れたページに着くだけで、Refresh Token は生きています）。

## 検証

`npm test` 全 13 スイート通過。紙面テストが inline script を `'<script>\n'` で切り出していたので、開きタグの変更に合わせて import 行を落とすよう直しました。`npm run build` で `dist/site/paper/vendor/` にクライアントが入ることも確認済みです。

## デプロイ

このリポジトリは GitHub Actions を持たないため、マージしても本番には出ません。`npm run deploy`（`cdk deploy --all`）が必要です。**path guard の変更を含むので、デプロイするまで新しい `index.html` は動きません**（HTML だけ先に出ると vendor が 404 になります）。CDK で両方まとめて出るので、通常の手順どおりで問題ありません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)